### PR TITLE
Removed caching from LinkEmbedder

### DIFF
--- a/lib/Mojolicious/Plugin/LinkEmbedder.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder.pm
@@ -59,7 +59,7 @@ Caching is EXPERIMENTAL and could be removed without notice.
   get '/embed' => sub {
     my $c = shift;
     my $url = $c->param('url');
-    my $cache = $app->defaults->{link_cache} ||= Mojo::Cache->new;
+    my $cache = $c->app->{linkembedder_cache} ||= Mojo::Cache->new;
     my $cached;
 
     $c->delay(
@@ -289,7 +289,7 @@ sub _add_action {
     cb => sub {
       my $c     = shift;
       my $url   = $c->param('url');
-      my $cache = $app->defaults->{link_cache} ||= Mojo::Cache->new;
+      my $cache = $c->app->{'linkembedder.cache'} ||= Mojo::Cache->new;
       my $cached;
 
       $c->delay(

--- a/lib/Mojolicious/Plugin/LinkEmbedder.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder.pm
@@ -81,7 +81,7 @@ Caching is EXPERIMENTAL and could be removed without notice.
               url => $link->{url},
             },
           },
-          any => { text => $link->{markup} }
+          any => { text => $link->{html} }
         );
       }
     );
@@ -302,7 +302,7 @@ sub _add_action {
           my ($delay, $link) = @_;
           $link = $link->TO_JSON if UNIVERSAL::can($link, 'TO_JSON');
           $cache->set($url => $link);
-          $c->respond_to(json => {json => $link}, any => {text => $link->{markup}});
+          $c->respond_to(json => {json => $link}, any => {text => $link->{html}});
         }
       );
     }

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Game/_2play.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Game/_2play.pm
@@ -18,9 +18,12 @@ use Mojo::Base 'Mojolicious::Plugin::LinkEmbedder::Link::Game';
 
 Returns the second path segment from L</url>.
 
+=head2 provider_name
+
 =cut
 
 has media_id => sub { shift->url->path->[2] || '' };
+sub provider_name {'2play'}
 sub _js_embed_url {'http://video.nettavisen.no/javascripts/embed.js'}
 
 =head1 METHODS

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Image/Imgur.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Image/Imgur.pm
@@ -29,9 +29,12 @@ URL to the image itself, extracted from the retrieved page
 
 The title of the image, extracted from the retrieved page
 
+=head2 provider_name
+
 =cut
 
 has media_id => sub { shift->url->path->[0] };
+sub provider_name {'Imgur'}
 has [qw(media_url media_title)];
 
 =head1 METHODS

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Image/Imgur.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Image/Imgur.pm
@@ -34,10 +34,6 @@ The title of the image, extracted from the retrieved page
 has media_id => sub { shift->url->path->[0] };
 has [qw(media_url media_title)];
 
-sub _cache_attributes {
-  shift->SUPER::_cache_attributes, qw( media_url media_title );
-}
-
 =head1 METHODS
 
 =head2 learn

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Image/Xkcd.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Image/Xkcd.pm
@@ -25,10 +25,6 @@ The C<img> link extracted from the retrieved page
 
 Extracts the media_id from the url directly
 
-=cut
-
-has media_id => sub { shift->url->path->[0] };
-
 =head2 media_url
 
 URL to the image itself, extracted from the retrieved page
@@ -41,9 +37,13 @@ The title of the image, extracted from the retrieved page
 
 The secret part of xkcd jokes
 
+=head2 provider_name
+
 =cut
 
-has [qw/actual_link media_url media_title media_hover_text/];
+has media_id => sub { shift->url->path->[0] };
+sub provider_name {'Xkcd'}
+has [qw(actual_link media_url media_title media_hover_text)];
 
 =head1 METHODS
 

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Text/GistGithub.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Text/GistGithub.pm
@@ -50,6 +50,12 @@ has media_id => sub {
   shift->url->path =~ m!^(/\w+/\w+)(?:\.js)?$! ? $1 : '';
 };
 
+=head2 provider_name
+
+=cut
+
+sub provider_name {'Github'}
+
 =head1 METHODS
 
 =head2 to_embed

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Text/Github.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Text/Github.pm
@@ -12,6 +12,14 @@ This class inherit from L<Mojolicious::Plugin::LinkEmbedder::Link::Text::HTML>.
 
 use Mojo::Base 'Mojolicious::Plugin::LinkEmbedder::Link::Text::HTML';
 
+=head1 ATTRIBUTES
+
+=head2 provider_name
+
+=cut
+
+sub provider_name {'Github'}
+
 sub _learn_from_dom {
   my ($self, $dom) = @_;
   my $e;

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Text/HTML.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Text/HTML.pm
@@ -49,10 +49,6 @@ has title       => '';
 has type        => '';
 has video       => '';
 
-sub _cache_attributes {
-  shift->SUPER::_cache_attributes, qw( canon_url description image title type video );
-}
-
 =head1 METHODS
 
 =head2 learn

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Text/Metacpan.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Text/Metacpan.pm
@@ -12,6 +12,14 @@ This class inherit from L<Mojolicious::Plugin::LinkEmbedder::Link::HTML>.
 
 use Mojo::Base 'Mojolicious::Plugin::LinkEmbedder::Link::Text::HTML';
 
+=head1 ATTRIBUTES
+
+=head2 provider_name
+
+=cut
+
+sub provider_name {'Metacpan'}
+
 sub _learn_from_dom {
   my ($self, $dom) = @_;
 

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Text/Twitter.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Text/Twitter.pm
@@ -20,11 +20,15 @@ use Mojo::Base 'Mojolicious::Plugin::LinkEmbedder::Link::Text';
 
 Example C<$str>: "/username/status/123456789".
 
+=head2 provider_name
+
 =cut
 
 has media_id => sub {
   shift->url->path =~ m!^/(\w+/status/\w+)$! ? $1 : '';
 };
+
+sub provider_name {'Twitter'}
 
 =head1 METHODS
 

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Blip.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Blip.pm
@@ -14,6 +14,14 @@ This class inherit from L<Mojolicious::Plugin::LinkEmbedder::Link::Text::HTML>.
 
 use Mojo::Base 'Mojolicious::Plugin::LinkEmbedder::Link::Text::HTML';
 
+=head1 ATTRIBUTES
+
+=head2 provider_name
+
+=cut
+
+sub provider_name {'Blip'}
+
 =head1 METHODS
 
 =head2 learn

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Collegehumor.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Collegehumor.pm
@@ -18,9 +18,12 @@ use Mojo::Base 'Mojolicious::Plugin::LinkEmbedder::Link::Text::HTML';
 
 Returns the the digit from the second path part from L</url>.
 
+=head2 provider_name
+
 =cut
 
 has media_id => sub { shift->url->path =~ m!/(\d+)/! ? $1 : '' };
+sub provider_name {'Collegehumor'}
 
 =head1 METHODS
 

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Dbtv.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Dbtv.pm
@@ -18,6 +18,8 @@ use Mojo::Base 'Mojolicious::Plugin::LinkEmbedder::Link::Video';
 
 Returns the the digit from the url L</url>.
 
+=head2 provider_name
+
 =cut
 
 has media_id => sub {
@@ -26,6 +28,8 @@ has media_id => sub {
 
   $url->query->param('vid') || $url->path->[-1];
 };
+
+sub provider_name {'Dagbladet'}
 
 =head1 METHODS
 

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Ted.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Ted.pm
@@ -18,6 +18,8 @@ use Mojo::Base 'Mojolicious::Plugin::LinkEmbedder::Link::Text::HTML';
 
 Returns the the digit from the url L</url>.
 
+=head2 provider_name
+
 =cut
 
 has media_id => sub {
@@ -27,6 +29,8 @@ has media_id => sub {
   $media_id =~ s!\.html$!!;
   $media_id;
 };
+
+sub provider_name {'Ted'}
 
 =head1 METHODS
 

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Vimeo.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Vimeo.pm
@@ -18,6 +18,8 @@ use Mojo::Base 'Mojolicious::Plugin::LinkEmbedder::Link::Text::HTML';
 
 Returns the the digit from the url L</url>.
 
+=head2 provider_name
+
 =cut
 
 has media_id => sub {
@@ -27,6 +29,8 @@ has media_id => sub {
   $media_id =~ s!\.html$!!;
   $media_id;
 };
+
+sub provider_name {'Vimeo'}
 
 =head1 METHODS
 

--- a/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Youtube.pm
+++ b/lib/Mojolicious/Plugin/LinkEmbedder/Link/Video/Youtube.pm
@@ -20,9 +20,12 @@ use Mojo::Base 'Mojolicious::Plugin::LinkEmbedder::Link::Text::HTML';
 
 Returns the "v" query param value from L</url>.
 
+=head2 provider_name
+
 =cut
 
 has media_id => sub { shift->url->query->param('v') || '' };
+sub provider_name {'YouTube'}
 
 =head1 METHODS
 

--- a/t/App.pm
+++ b/t/App.pm
@@ -1,7 +1,5 @@
 package t::App;
-
-use strict;
-use warnings;
+use Mojo::Base -strict;
 use Mojolicious;
 use Test::Mojo;
 use Test::More;


### PR DESCRIPTION
Instead of putting caching as a core feature, I want to make it simpler to add caching externally. I'm still keeping caching for the simple case to let linkembedder be easily integrated into apps.

The TO_JSON() method might need some work, but I think it's good enough (as in not worse) now.